### PR TITLE
Enable character detail sheet from party detail silhouettes

### DIFF
--- a/Epika/UI/Components/PartyCharacterSilhouettesView.swift
+++ b/Epika/UI/Components/PartyCharacterSilhouettesView.swift
@@ -25,6 +25,13 @@ import SwiftUI
 struct PartyCharacterSilhouettesView: View {
     let party: PartySnapshot
     let characters: [RuntimeCharacter]
+    let onMemberTap: ((RuntimeCharacter) -> Void)?
+
+    init(party: PartySnapshot, characters: [RuntimeCharacter], onMemberTap: ((RuntimeCharacter) -> Void)? = nil) {
+        self.party = party
+        self.characters = characters
+        self.onMemberTap = onMemberTap
+    }
 
     private var orderedMembers: [RuntimeCharacter] {
         party.memberIds.compactMap { id in
@@ -51,18 +58,7 @@ struct PartyCharacterSilhouettesView: View {
                         Group {
                             if index < orderedMembers.count {
                                 let member = orderedMembers[index]
-                                VStack(spacing: 2) {
-                                    CharacterImageView(avatarIndex: member.resolvedAvatarId, size: 55)
-                                    VStack(spacing: 1) {
-                                        Text("Lv.\(member.level)")
-                                            .font(.caption2)
-                                            .foregroundStyle(.primary)
-                                        Text("HP\(member.currentHP)")
-                                            .font(.caption2)
-                                            .foregroundStyle(.secondary)
-                                    }
-                                }
-                                .frame(width: 48)
+                                memberSilhouette(member)
                             } else {
                                 Spacer()
                                     .frame(width: 48)
@@ -78,5 +74,30 @@ struct PartyCharacterSilhouettesView: View {
         }
         .frame(maxWidth: .infinity)
         .contentShape(Rectangle())
+    }
+
+    @ViewBuilder
+    private func memberSilhouette(_ member: RuntimeCharacter) -> some View {
+        let content = VStack(spacing: 2) {
+            CharacterImageView(avatarIndex: member.resolvedAvatarId, size: 55)
+            VStack(spacing: 1) {
+                Text("Lv.\(member.level)")
+                    .font(.caption2)
+                    .foregroundStyle(.primary)
+                Text("HP\(member.currentHP)")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(width: 48)
+
+        if let onMemberTap {
+            Button(action: { onMemberTap(member) }) {
+                content
+            }
+            .buttonStyle(.plain)
+        } else {
+            content
+        }
     }
 }

--- a/Epika/UI/Components/PartySlotCardView.swift
+++ b/Epika/UI/Components/PartySlotCardView.swift
@@ -29,6 +29,7 @@ struct PartySlotCardView<Footer: View>: View {
     let isExploring: Bool
     let canStartExploration: Bool
     let onPrimaryAction: () -> Void
+    let onMemberTap: ((RuntimeCharacter) -> Void)?
     let onMembersTap: (() -> Void)?
     private let footerBuilder: (() -> Footer)?
     init(party: PartySnapshot,
@@ -37,6 +38,7 @@ struct PartySlotCardView<Footer: View>: View {
          isExploring: Bool,
          canStartExploration: Bool,
          onPrimaryAction: @escaping () -> Void,
+         onMemberTap: ((RuntimeCharacter) -> Void)? = nil,
          onMembersTap: (() -> Void)? = nil,
          @ViewBuilder footer: @escaping () -> Footer) {
         self.party = party
@@ -45,6 +47,7 @@ struct PartySlotCardView<Footer: View>: View {
         self.isExploring = isExploring
         self.canStartExploration = canStartExploration
         self.onPrimaryAction = onPrimaryAction
+        self.onMemberTap = onMemberTap
         self.onMembersTap = onMembersTap
         self.footerBuilder = footer
     }
@@ -55,6 +58,7 @@ struct PartySlotCardView<Footer: View>: View {
          isExploring: Bool,
          canStartExploration: Bool,
          onPrimaryAction: @escaping () -> Void,
+         onMemberTap: ((RuntimeCharacter) -> Void)? = nil,
          onMembersTap: (() -> Void)? = nil)
     where Footer == EmptyView {
         self.party = party
@@ -63,6 +67,7 @@ struct PartySlotCardView<Footer: View>: View {
         self.isExploring = isExploring
         self.canStartExploration = canStartExploration
         self.onPrimaryAction = onPrimaryAction
+        self.onMemberTap = onMemberTap
         self.onMembersTap = onMembersTap
         self.footerBuilder = nil
     }
@@ -135,7 +140,9 @@ struct PartySlotCardView<Footer: View>: View {
 
     @ViewBuilder
     private var membersRow: some View {
-        if let onMembersTap {
+        if let onMemberTap {
+            PartyCharacterSilhouettesView(party: party, characters: members, onMemberTap: onMemberTap)
+        } else if let onMembersTap {
             Button(action: onMembersTap) {
                 PartyCharacterSilhouettesView(party: party, characters: members)
                     .contentShape(Rectangle())

--- a/Epika/UI/SubScreens/RuntimePartyDetailView.swift
+++ b/Epika/UI/SubScreens/RuntimePartyDetailView.swift
@@ -35,6 +35,7 @@ struct RuntimePartyDetailView: View {
     @State private var allCharacters: [RuntimeCharacter] = []
     @State private var errorMessage: String?
     @State private var showDungeonPicker = false
+    @State private var selectedCharacter: RuntimeCharacter?
 
     init(party: PartySnapshot, selectedDungeon: Binding<RuntimeDungeon?>, dungeons: [RuntimeDungeon]) {
         _currentParty = State(initialValue: party)
@@ -55,6 +56,9 @@ struct RuntimePartyDetailView: View {
                         onPrimaryAction: {
                             handlePrimaryAction(isExploring: adventureState.isExploring(partyId: currentParty.id),
                                                 canDepart: canStartExploration(for: currentParty))
+                        },
+                        onMemberTap: { character in
+                            selectedCharacter = character
                         }
                     )
                     .padding(.vertical, 4)
@@ -164,6 +168,11 @@ struct RuntimePartyDetailView: View {
                     }
                 )
             }
+            .sheet(isPresented: isCharacterDetailPresented) {
+                if let character = selectedCharacter {
+                    RuntimeCharacterDetailSheetView(character: character)
+                }
+            }
         }
         .overlay(alignment: .bottomLeading) {
             StatChangeNotificationView()
@@ -195,6 +204,15 @@ struct RuntimePartyDetailView: View {
     private var listRowHeight: CGFloat? {
         let value = AppConstants.UI.listRowHeight
         return value > 0 ? value : nil
+    }
+
+    private var isCharacterDetailPresented: Binding<Bool> {
+        Binding(
+            get: { selectedCharacter != nil },
+            set: { isPresented in
+                if !isPresented { selectedCharacter = nil }
+            }
+        )
     }
 
     private func errorView(_ message: String) -> some View {


### PR DESCRIPTION
## Summary
- add per-member tap handling to the party silhouette grid
- allow party slot cards to forward member taps separately from whole-row taps
- present the character detail sheet from the party detail screen when a silhouette is tapped

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953f39d08a4832baacc37e3c77e00e4)